### PR TITLE
Fixed typo on ERC20 transfer page

### DIFF
--- a/NethereumBlazor/Pages/Erc20Transfer.cshtml
+++ b/NethereumBlazor/Pages/Erc20Transfer.cshtml
@@ -42,7 +42,7 @@
             </div>
         </div>
         <div class="form-group row">
-            <label for="" class="col-sm-1 col-form-label">Contract Address:</label>
+            <label for="" class="col-sm-1 col-form-label">Decimal Places:</label>
             <div class="col-sm-10">
                 <input id="TokenDecimalPlaces" class="form-control" bind="@SendTransactionViewModel.DecimalPlaces" type="text" />
                 <small id="TokenDecimalPlacesHelp" class="form-text text-muted">The number of decimal places of ERC20 Token</small>


### PR DESCRIPTION
On the ERC20 Transfer page, fixed the label for decimal places to say "decimal places" instead of "contract address":

![untitled](https://user-images.githubusercontent.com/5543867/52331979-5ddafa80-29f1-11e9-8d36-eeb5e045b231.png)
